### PR TITLE
Updated test.py - Modified testSpi() and testNumPixels()

### DIFF
--- a/Led_Strip_Library/tests/test.py
+++ b/Led_Strip_Library/tests/test.py
@@ -14,17 +14,20 @@ class TestLEDStrip(unittest.TestCase):
 	##
 	# testSpi		Tests if the SPI connection is working.
 	def testSpi(self):
-		spidev = file(self.spidevFile, "wb")
-		leds = ledstrip.LEDStrip(self.numberOfPixels,spidev)
-		self.assertTrue(leds.spi,"SPI interface could not be opened")
+		spidev = open(self.spidevFile, "wb")
+		leds = ledstrip.LEDStrip(self.numberOfPixels, spidev)
+		self.assertTrue(leds.spi, "SPI interface could not be opened")
 
 	##
 	# testNumPixels	Tests if the number of pixels is set properly.
 	def testNumPixels(self):
-		spidev = file(self.spidevFile, "wb")
-		leds = ledstrip.LEDStrip(self.numberOfPixels,spidev)
-		self.assertTrue(leds.spi,"SPI interface could not be opened")
-		self.assertTrue(self.numberOfPixels==leds.numPixels(),"Number of pixels do not match")
+		try:
+			spidev = open(self.spidevFile, "wb") # spidev is the file object of the SPI connection
+		except IOError:
+			self.assertRaises(IOError, open, self.spidevFile, "wb") # raise IOError if SPI interface could not be initialized
+		else: # if SPI interface is successfully initialized, perform numPixels check
+			leds = ledstrip.LEDStrip(self.numberOfPixels,spidev)
+			self.assertEqual(self.numberOfPixels,leds.numPixels(), "Number of pixels do not match") # assert equality of numberOfPixels and value returned by numPixels()
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Since Python 3.0, open( ) is preferred to file( ), hence I changed the file( ) call to open( ). Both function calls return objects of "file" type.

Added try-except-else block for SPI interface checking. If we are able to messages along with assertRaises(), then we can also add the same thing to testSpi() as well.
